### PR TITLE
Cater for the new Bundle config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,20 @@ produced by the native packager.
 Hitting return will cause the bundle to be uploaded. On successfully uploading the bundle the plugin will report
 the `BundleId` to use for subsequent commands on that bundle.
 
-#### To use sbt-typesafe-conductr in your own project
+### To use sbt-typesafe-conductr in your own project
 
 Add the `sbt-typesafe-conductr` plugin:
 
 ```scala
 addSbtPlugin("com.typesafe.typesafeconductr" % "sbt-typesafe-conductr" % "0.10.0")
+```
+
+You must also enable the plugin explicitly for your project:
+
+```scala
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(SbtTypesafeConductR, <your other plugins go here>)
 ```
 
 If you will be creating bundles then you may override the following native packager properties:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Version {
   val jansi            = "1.11"
   val jline            = "2.12"
   val play             = "2.4.0-M1"
-  val sbtBundle        = "0.5.0"
+  val sbtBundle        = "0.6.0"
   val scalaTest        = "2.2.2"
   val scalactic        = "2.2.2"
 }

--- a/src/main/scala/com/typesafe/typesafeconductr/sbt/SbtTypesafeConductR.scala
+++ b/src/main/scala/com/typesafe/typesafeconductr/sbt/SbtTypesafeConductR.scala
@@ -73,7 +73,7 @@ object SbtTypesafeConductR extends AutoPlugin {
   override def projectSettings: Seq[Setting[_]] =
     List(
       commands ++= Seq(bundleInfo, conductr),
-      discoveredDist <<= (dist in ConductR).storeAs(discoveredDist in Global).triggeredBy(dist in ConductR),
+      discoveredDist <<= (dist in Bundle).storeAs(discoveredDist in Global).triggeredBy(dist in Bundle),
       loadBundle := loadBundleTask.value.evaluated,
       roles := Set.empty,
       startBundle := startBundleTask.value.evaluated,


### PR DESCRIPTION
The `sbt-bundle` `ConductR` config has been renamed to `Bundle`.

Documentation has also been improved.