### PR TITLE
Print and quit in bundleInfo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-lazy val sbtReactiveRuntime = project.in(file("."))
+lazy val sbtTypesafeConductR = project.in(file("."))
 
 name := "sbt-typesafe-conductr"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 object Version {
   val akka             = "2.3.7"
-  val akkaContribExtra = "1.0.3"
-  val akkaHttp         = "0.11"
+  val akkaContribExtra = "1.1.1"
+  val akkaHttp         = "1.0-M2"
   val jansi            = "1.11"
   val jline            = "2.12"
   val play             = "2.4.0-M1"

--- a/src/main/scala/com/typesafe/typesafeconductr/ConductRController.scala
+++ b/src/main/scala/com/typesafe/typesafeconductr/ConductRController.scala
@@ -221,7 +221,7 @@ class ConductRController(uri: Uri, connectTimeout: Timeout)
   private def fetchBundleFlow(originalSender: ActorRef): Unit = {
     import scala.concurrent.duration._
     // TODO this needs to be driven by SSE and not by the timer
-    val source = Source(0.millis, 2.seconds, () => ()).mapAsync(_ => getBundles)
+    val source = Source(100.millis, 2.seconds, () => ()).mapAsync(_ => getBundles)
     originalSender ! BundleInfosSource(source)
   }
 

--- a/src/main/scala/com/typesafe/typesafeconductr/console/Columns.scala
+++ b/src/main/scala/com/typesafe/typesafeconductr/console/Columns.scala
@@ -101,9 +101,9 @@ object Column {
 
     val data: Seq[Seq[String]] =
       bundles.map { bundle =>
-        bundle.nodeBundleFiles.map { node =>
-          val nodeIpAndPort = node.address.dropWhile(_ != '@').drop(1)
-          if (node.executing)
+        bundle.bundleInstallations.map { node =>
+          val nodeIpAndPort = node.uniqueAddress.address.toString.dropWhile(_ != '@').drop(1)
+          if (bundle.bundleExecutions.map(_.host) contains node.uniqueAddress.address.host.get)
             nodeIpAndPort.invert
           else
             nodeIpAndPort
@@ -120,7 +120,7 @@ object Column {
 
     val data: Seq[Seq[String]] =
       bundles.map { bundle =>
-        List(bundle.nodeBundleFiles.count(_.executing).toString)
+        List(bundle.bundleExecutions.size.toString)
       }
   }
 

--- a/src/main/scala/com/typesafe/typesafeconductr/package.scala
+++ b/src/main/scala/com/typesafe/typesafeconductr/package.scala
@@ -4,6 +4,12 @@
 
 package com.typesafe
 
+import akka.actor.{ Address, AddressFromURIString }
+import akka.cluster.UniqueAddress
+import com.typesafe.typesafeconductr.ConductRController.{ BundleExecution, BundleInfo, BundleInstallation, SchedulingRequirement }
+import play.api.libs.json.{ Format, Json, JsResult, JsString, JsValue }
+import java.net.URI
+
 package object typesafeconductr {
 
   type Traversable[+A] = scala.collection.immutable.Traversable[A]
@@ -13,4 +19,29 @@ package object typesafeconductr {
   type Seq[+A] = scala.collection.immutable.Seq[A]
 
   type IndexedSeq[+A] = scala.collection.immutable.IndexedSeq[A]
+
+  implicit object AddressFormat extends Format[Address] {
+    override def writes(address: Address): JsValue = JsString(address.toString)
+    override def reads(json: JsValue): JsResult[Address] = implicitly[Format[String]].reads(json).map(AddressFromURIString(_))
+  }
+
+  implicit object UriFormat extends Format[URI] {
+    override def writes(uri: URI): JsValue = implicitly[Format[String]].writes(uri.toString)
+    override def reads(json: JsValue): JsResult[URI] = implicitly[Format[String]].reads(json).map(new URI(_))
+  }
+
+  implicit val uniqueAddressFormat: Format[UniqueAddress] =
+    Json.format
+
+  implicit val schedulingRequirementFormat: Format[SchedulingRequirement] =
+    Json.format
+
+  implicit val bundleInstallationFormat: Format[BundleInstallation] =
+    Json.format
+
+  implicit val bundleExecutionFormat: Format[BundleExecution] =
+    Json.format
+
+  implicit val bundleInfoFormat: Format[BundleInfo] =
+    Json.format
 }

--- a/src/main/scala/com/typesafe/typesafeconductr/sbt/SbtTypesafeConductR.scala
+++ b/src/main/scala/com/typesafe/typesafeconductr/sbt/SbtTypesafeConductR.scala
@@ -249,7 +249,7 @@ object SbtTypesafeConductR extends AutoPlugin {
           for {
             url <- (conductrUrl in Global).get(settings)
             connectTimeout <- (conductrConnectTimeout in Global).get(settings)
-          } yield system.actorOf(ConductRController.props(HttpUri(url.toString), connectTimeout, akka.io.IO(Http)))
+          } yield system.actorOf(ConductRController.props(HttpUri(url.toString), connectTimeout))
         conductr.getOrElse(sys.error("Cannot establish the ConductRController actor: Check that you have conductrUrl and conductrConnectTimeout settings!"))
       }
       state.put(conductrAttrKey, conductr)

--- a/src/main/scala/com/typesafe/typesafeconductr/sbt/SbtTypesafeConductR.scala
+++ b/src/main/scala/com/typesafe/typesafeconductr/sbt/SbtTypesafeConductR.scala
@@ -104,8 +104,8 @@ object SbtTypesafeConductR extends AutoPlugin {
     def unloadBundle = bundleId(Nil) // FIXME: Should default to last bundle loaded
   }
 
-  private def bundleInfo: Command = Command.command("bundleInfo") { state =>
-    withActorSystem(state)(withConductRController(state)(Console.bundleInfo))
+  private def bundleInfo: Command = Command.args("bundleInfo", "Refresh screen: -r") { (state, flags) =>
+    withActorSystem(state)(withConductRController(state)(Console.bundleInfo(flags contains "-r")))
     state
   }
 


### PR DESCRIPTION
`bundleInfo` command now prints bundle information and quits by default. Previous full-screen refreshing mode (now under `-r` flag) is still there, mainly because it was easy to have both modes.

This builds on #16 and #18, thus only last commit is worthy a review.