### PR TITLE
Update sbt-bundle.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Version {
   val jansi            = "1.11"
   val jline            = "2.12"
   val play             = "2.4.0-M1"
-  val sbtBundle        = "0.8.0"
+  val sbtBundle        = "0.9.0"
   val scalaTest        = "2.2.2"
   val scalactic        = "2.2.2"
 }


### PR DESCRIPTION
MERGE ONLY AFTER SBT-BUNDLE 0.9.0 is released.

This actually fixes #20 because no JSON format changes are necessary as [ports are never parsed out](https://github.com/2m/sbt-typesafe-conductr/blob/640cdce0b24e143797c112101b32f821e486723c/src/main/scala/com/typesafe/typesafeconductr/ConductRController.scala#L82-L86).